### PR TITLE
feat(order): implementa criação de pedidos com persistência e publicação na fila RabbitMQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM gradle:8.5-jdk21 AS build
+
+WORKDIR /app
+
+COPY . .
+
+RUN gradle clean build -x test
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,8 @@ group = "com.example"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
@@ -22,11 +21,14 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+	implementation("org.jboss.logging:jboss-logging:3.5.0.Final")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.springframework.boot:spring-boot-starter-amqp")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
-	runtimeOnly("org.postgresql:postgresql")
+	implementation("org.postgresql:postgresql:42.6.0")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    depends_on:
+      - db
+      - rabbitmq
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+    ports:
+      - "8080:8080"
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: FoodOrderingSystem
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: admin
+    ports:
+      - "5432:5432"
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_USER: myuser
+      RABBITMQ_DEFAULT_PASS: secret
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "pedidos"
+rootProject.name = "FoodOrderingSystem"

--- a/src/main/kotlin/com/example/foodorderingsystem/FoodOrderingSystemApplication.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/FoodOrderingSystemApplication.kt
@@ -1,11 +1,11 @@
-package com.example.pedidos
+package com.example.foodorderingsystem
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class PedidosApplication
+class FoodOrderingSystemApplication
 
 fun main(args: Array<String>) {
-	runApplication<PedidosApplication>(*args)
+	runApplication<FoodOrderingSystemApplication>(*args)
 }

--- a/src/main/kotlin/com/example/foodorderingsystem/config/RabbitMQConfig.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/config/RabbitMQConfig.kt
@@ -1,0 +1,19 @@
+package com.example.foodorderingsystem.config
+
+import org.springframework.amqp.core.*
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RabbitMQConfig {
+
+    @Bean
+    fun exchange(): TopicExchange = TopicExchange("orders.exchange")
+
+    @Bean
+    fun queue(): Queue = Queue("orders.queue")
+
+    @Bean
+    fun binding(queue: Queue, exchange: TopicExchange): Binding =
+        BindingBuilder.bind(queue).to(exchange).with("orders.created")
+}

--- a/src/main/kotlin/com/example/foodorderingsystem/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/config/SecurityConfig.kt
@@ -1,0 +1,25 @@
+package com.example.foodorderingsystem.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.Customizer
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
+                it.requestMatchers("/orders/**").authenticated()
+                    .anyRequest().permitAll()
+            }
+            .httpBasic(Customizer.withDefaults())
+            .build()
+    }
+}

--- a/src/main/kotlin/com/example/foodorderingsystem/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/controller/OrderController.kt
@@ -1,0 +1,30 @@
+package com.example.foodorderingsystem.controller
+
+import com.example.foodorderingsystem.dto.CreateOrderRequest
+import com.example.foodorderingsystem.dto.OrderResponse
+import com.example.foodorderingsystem.service.OrderService
+
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/orders")
+class OrderController(
+    private val orderService: OrderService,
+) {
+    @PostMapping("/createOrder")
+    fun createOrder(
+        @RequestBody @Valid request: CreateOrderRequest
+    ): ResponseEntity<OrderResponse> {
+        val order = orderService.createOrder(request)
+        val response = OrderResponse(
+            orderId = order.id,
+            status = order.status.name,
+            customerName = order.customerName,
+            restaurant = order.restaurant
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(response)
+    }
+}

--- a/src/main/kotlin/com/example/foodorderingsystem/dto/CreateOrderRequest.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/dto/CreateOrderRequest.kt
@@ -1,0 +1,10 @@
+package com.example.foodorderingsystem.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+
+data class CreateOrderRequest(
+    @field:NotBlank val customerName: String,
+    @field:NotBlank val restaurant: String,
+    @field:NotEmpty val items: List<Item>
+)

--- a/src/main/kotlin/com/example/foodorderingsystem/dto/Item.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/dto/Item.kt
@@ -1,0 +1,8 @@
+package com.example.foodorderingsystem.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class Item(
+    @field:NotBlank val itemName: String,
+    @field:NotBlank val quantity: Int
+)

--- a/src/main/kotlin/com/example/foodorderingsystem/dto/OrderResponse.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/dto/OrderResponse.kt
@@ -1,0 +1,8 @@
+package com.example.foodorderingsystem.dto
+
+data class OrderResponse(
+    val orderId: Long,
+    val status: String,
+    val customerName: String,
+    val restaurant: String
+)

--- a/src/main/kotlin/com/example/foodorderingsystem/entity/Order.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/entity/Order.kt
@@ -1,0 +1,21 @@
+package com.example.foodorderingsystem.entity
+
+import OrderStatus
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "orders")
+data class Order(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val customerName: String,
+
+    val restaurant: String,
+
+    @Enumerated(EnumType.STRING)
+    val status: OrderStatus = OrderStatus.PENDING,
+
+    @OneToMany(mappedBy = "order", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val items: MutableList<OrderItem> = mutableListOf()
+)

--- a/src/main/kotlin/com/example/foodorderingsystem/entity/OrderItem.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/entity/OrderItem.kt
@@ -1,0 +1,17 @@
+package com.example.foodorderingsystem.entity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "order_items")
+data class OrderItem(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val itemName: String,
+
+    val quantity: Int = 1,
+
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    val order: Order
+)

--- a/src/main/kotlin/com/example/foodorderingsystem/entity/OrderStatus.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/entity/OrderStatus.kt
@@ -1,0 +1,3 @@
+enum class OrderStatus {
+    PENDING, PROCESSING, COMPLETED
+}

--- a/src/main/kotlin/com/example/foodorderingsystem/repository/OrderRepository.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/repository/OrderRepository.kt
@@ -1,0 +1,7 @@
+package com.example.foodorderingsystem.repository
+
+import com.example.foodorderingsystem.entity.Order
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+interface OrderRepository : JpaRepository<Order, Long>

--- a/src/main/kotlin/com/example/foodorderingsystem/service/OrderService.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/service/OrderService.kt
@@ -1,0 +1,8 @@
+package com.example.foodorderingsystem.service
+
+import com.example.foodorderingsystem.dto.CreateOrderRequest
+import com.example.foodorderingsystem.entity.Order
+
+interface OrderService  {
+    fun createOrder(request: CreateOrderRequest): Order
+}

--- a/src/main/kotlin/com/example/foodorderingsystem/service/OrderServiceImpl.kt
+++ b/src/main/kotlin/com/example/foodorderingsystem/service/OrderServiceImpl.kt
@@ -1,0 +1,49 @@
+package com.example.foodorderingsystem.service
+
+import com.example.foodorderingsystem.dto.CreateOrderRequest
+import com.example.foodorderingsystem.entity.Order
+import com.example.foodorderingsystem.entity.OrderItem
+import com.example.foodorderingsystem.repository.OrderRepository
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class OrderServiceImpl(
+    private val orderRepository: OrderRepository,
+    private val rabbitTemplate: RabbitTemplate
+) : OrderService {
+
+    override fun createOrder(request: CreateOrderRequest): Order {
+        val order = Order(
+            customerName = request.customerName,
+            restaurant = request.restaurant,
+            items = mutableListOf(),
+            status = OrderStatus.PENDING
+        )
+
+        val orderItems = request.items.map {
+            OrderItem(
+                itemName = it.itemName,
+                quantity = it.quantity,
+                order = order
+            )
+        }
+
+        order.items.addAll(orderItems)
+
+        val saved = orderRepository.save(order)
+
+        val payload = mapOf(
+            "orderId" to saved.id,
+            "customerName" to saved.customerName,
+            "restaurant" to saved.restaurant,
+            "items" to saved.items.map { it.itemName },
+            "status" to saved.status
+        )
+
+        rabbitTemplate.convertAndSend("orders.exchange", "orders.created", payload)
+
+        return saved
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://db:5432/FoodOrderingSystem
+    username: postgres
+    password: admin
+  rabbitmq:
+    host: rabbitmq
+    port: 5672
+    username: myuser
+    password: secret
+server:
+  port: 8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-spring.application.name=pedidos
+spring.application.name=FoodOrderingSystem

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  security:
+    user:
+      name: leticia
+      password: minhaSenhaSegura123
+  datasource:
+    url: jdbc:postgresql://localhost:5432/FoodOrderingSystem
+    username: postgres
+    password: admin
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: myuser
+    password: mypassword
+  logging:
+    level:
+      org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE
+
+server:
+  port: 8080

--- a/src/test/kotlin/com/example/foodorderingsystem/PedidosApplicationTests.kt
+++ b/src/test/kotlin/com/example/foodorderingsystem/PedidosApplicationTests.kt
@@ -1,10 +1,10 @@
-package com.example.pedidos
+package com.example.foodorderingsystem
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
-class PedidosApplicationTests {
+class FoodOrderingSystemApplicationTests {
 
 	@Test
 	fun contextLoads() {


### PR DESCRIPTION
### 🟦 HU01 - Criar Pedido

**Objetivo:** Permitir que clientes registrem pedidos via `POST /orders` para processamento assíncrono posterior.

**Alterações realizadas:**
- Endpoint `POST /orders`
- Validação de entrada via DTO
- Salvamento no banco com status `PENDING`
- Publicação da mensagem na fila `orders.queue` (RabbitMQ)